### PR TITLE
Change Log in to use 2FA

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -305,7 +305,7 @@ class AugustPlatform {
       var self = this;
   
       // Log in
-      var authenticate = this.augustApi.authorize();
+      var authenticate = this.augustApi.authorize(this.code);
       authenticate.then(function (result) {
         self.postLogin(callback);
       }, function (error) {


### PR DESCRIPTION
Changing this line to take the 2FA code makes logging in work. I'm able to see and control the lock from HomeKit.

(It's unclear if restarting Homebridge makes it request a new 2FA.)